### PR TITLE
feat: Apply getters when invoking `toObject()`

### DIFF
--- a/src/mongoose-cleaner.js
+++ b/src/mongoose-cleaner.js
@@ -23,7 +23,10 @@ const api = {
     let lean = mongoose_doc;
 
     if (isLookingLikeMongooseDocument(mongoose_doc)) {
-      lean = mongoose_doc.toObject();
+      lean = mongoose_doc.toObject({
+        getters: true,
+        virtuals: false,
+      });
     }
 
     delete lean.__v;


### PR DESCRIPTION
feat: Apply getters when invoking `toObject()`

Will ensure getters are used as expected.